### PR TITLE
Fix for null value instead of empty string

### DIFF
--- a/spec/watoki/dom/PrinterTest.php
+++ b/spec/watoki/dom/PrinterTest.php
@@ -49,10 +49,14 @@ class PrinterTest extends Test {
     }
 
     function testAttributes() {
-        $this->when->iPrintTheMarkup('<element empty unquoted=value single=\'quoted\' quoted="value"/>');
-        $this->then->itShouldPrint('<element empty unquoted=value single=\'quoted\' quoted="value"/>');
+        $this->when->iPrintTheMarkup('<element unquoted=value single=\'quoted\' quoted="value"/>');
+        $this->then->itShouldPrint('<element unquoted=value single=\'quoted\' quoted="value"/>');
     }
 
+    function testEmptyAttributes() {
+        $this->when->iPrintTheMarkup('<element empty quoted="" single=\'\'/>');
+        $this->then->itShouldPrint('<element empty quoted="" single=\'\'/>');
+    }
 }
 
 /**

--- a/src/watoki/dom/fsm/AttributeValueState.php
+++ b/src/watoki/dom/fsm/AttributeValueState.php
@@ -15,10 +15,12 @@ class AttributeValueState extends AttributeState {
     }
 
     public function onDoubleQuote($char) {
+        $this->buffer->addToAttributeValue('');
         return DoubleQuotedAttributeValueState::$CLASS;
     }
 
     public function onSingleQuote($char) {
+        $this->buffer->addToAttributeValue('');
         return SingleQuotedAttributeValueState::$CLASS;
     }
 }


### PR DESCRIPTION
When quoted value is encountered adds empty string to value. effectively changes null to empty string.
